### PR TITLE
d855: decommonize NFC config and HCE permission

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -38,6 +38,9 @@ TARGET_USERIMAGES_USE_F2FS := true
 # Recovery
 TARGET_RECOVERY_FSTAB := device/lge/d855/rootdir/etc/fstab.g3
 
+# NFC
+BOARD_NFC_CHIPSET := pn547
+
 # Wifi
 BOARD_HAS_QCOM_WLAN := true
 BOARD_WLAN_DEVICE := qcwcn

--- a/device.mk
+++ b/device.mk
@@ -23,6 +23,10 @@ $(call inherit-product-if-exists, vendor/lge/d855/d855-vendor.mk)
 PRODUCT_COPY_FILES += \
     device/lge/g3-common/configs/mixer_paths_qcwcn.xml:system/etc/mixer_paths.xml
 
+# NFC
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.nfc.hce.xml:system/etc/permissions/android.hardware.nfc.hce.xml
+
 # Overlays
 DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 
@@ -40,6 +44,11 @@ PRODUCT_PACKAGES += \
     hostapd_default.conf \
     libwcnss_qmi \
     wcnss_service
+
+# NFC packages
+PRODUCT_PACKAGES += \
+    NfcNci \
+    nfc_nci.pn54x.default
 
 PRODUCT_COPY_FILES += \
     device/lge/g3-common/wcnss/WCNSS_cfg.dat:system/etc/firmware/wlan/prima/WCNSS_cfg.dat \


### PR DESCRIPTION
* The ls990 uses a pn544 instead of a pn547 so move BOARD_NFC_CHIPSET
  to the device folders
* Since the pn544 doesn't support HCE, move the permission for it
  to the device folders as well, otherwise, it will cause linker
  errors on the ls990
* Move NFC HALs to device repos since they don't work on pn544

Change-Id: Icd93c2dda3b564c25153e6318f2cf70413925ddc